### PR TITLE
Replaces usage of printf by print or println in the affected files.

### DIFF
--- a/src/main/java/edu/ucla/sspace/matrix/MatlabSparseFileTransformer.java
+++ b/src/main/java/edu/ucla/sspace/matrix/MatlabSparseFileTransformer.java
@@ -58,8 +58,9 @@ public class MatlabSparseFileTransformer implements FileTransformer {
                 int row = Integer.parseInt(rowColEntry[0]);
                 int col = Integer.parseInt(rowColEntry[1]);
                 double value = Double.parseDouble(rowColEntry[2]);
-                writer.printf("%d %d %f\n", row, col, 
-                              transform.transform(row-1, col-1, value));
+                StringBuilder stringBuilder = new StringBuilder();
+                stringBuilder.append(row).append(" ").append(col).append(" ").append(transform.transform(row-1, col-1, value));
+                writer.println(stringBuilder.toString());
             }
             writer.close();
 

--- a/src/main/java/edu/ucla/sspace/matrix/SvdlibcSparseTextFileTransformer.java
+++ b/src/main/java/edu/ucla/sspace/matrix/SvdlibcSparseTextFileTransformer.java
@@ -58,13 +58,13 @@ class SvdlibcSparseTextFileTransformer implements FileTransformer {
             int numTotalNonZeros = Integer.parseInt(rowColNonZeroCount[2]);
 
             // Write out the header for the new matrix file.
-            writer.printf("%d %d %d\n", numRows, numCols, numTotalNonZeros);
+            writer.println(numRows + " " + numCols + " " + numTotalNonZeros);
 
             line = br.readLine();
             // Traverse each column in the matrix.
             for (int col = 0; line != null && col < numCols; ++col) {
                 int numNonZeros = Integer.parseInt(line);
-                writer.printf("%d\n", numNonZeros);
+                writer.println(numNonZeros);
 
                 // Transform each of the non zero values for the new matrix
                 // file.
@@ -73,8 +73,9 @@ class SvdlibcSparseTextFileTransformer implements FileTransformer {
                     String[] rowValue = line.split("\\s+");
                     int row = Integer.parseInt(rowValue[0]);
                     double value = Double.parseDouble(rowValue[1]);
-                    writer.printf("%d %f\n", row,
-                                  transform.transform(row, col, value));
+                    StringBuilder stringBuilder = new StringBuilder();
+                    stringBuilder.append(row).append(" ").append(transform.transform(row, col, value));
+                    writer.println(stringBuilder.toString());
                 }
             }
 

--- a/src/test/java/edu/ucla/sspace/matrix/ClutoSparseFileIteratorTests.java
+++ b/src/test/java/edu/ucla/sspace/matrix/ClutoSparseFileIteratorTests.java
@@ -74,14 +74,15 @@ public class ClutoSparseFileIteratorTests {
         File f = File.createTempFile("unit-test",".dat");
         PrintWriter pw = new PrintWriter(f);
         
-        pw.printf("%d %d %d\n", testMatrix.length, testMatrix[0].length, 7);
-
-        for (int r = 0; r < testMatrix.length; ++r) {
-            for (int c = 0; c < testMatrix[0].length; ++c)
-                if (testMatrix[r][c] != 0d)
-                    pw.printf("%d %f ", c+1, (float)testMatrix[r][c]);
-            pw.println();
-        }
+        pw.println(testMatrix.length + " " + testMatrix[0].length + " " + 7);
+        
+		for (int r = 0; r < testMatrix.length; ++r) {
+			for (int c = 0; c < testMatrix[0].length; ++c)
+				if (testMatrix[r][c] != 0d)
+					pw.print((c + 1) + " " + (float) testMatrix[r][c] + " ");
+			pw.println();
+		}
+		pw.close();
 
         pw.close();
         return f;

--- a/src/test/java/edu/ucla/sspace/matrix/DenseTextFileIteratorTests.java
+++ b/src/test/java/edu/ucla/sspace/matrix/DenseTextFileIteratorTests.java
@@ -75,7 +75,7 @@ public class DenseTextFileIteratorTests {
         
         for (int r = 0; r < testMatrix.length; ++r) {
             for (int c = 0; c < testMatrix[0].length; ++c)
-                pw.printf("%f ", (float)testMatrix[r][c]);
+                pw.print((float)testMatrix[r][c] + " ");
             pw.println();
         }
 

--- a/src/test/java/edu/ucla/sspace/matrix/MatlabSparseFileIteratorTests.java
+++ b/src/test/java/edu/ucla/sspace/matrix/MatlabSparseFileIteratorTests.java
@@ -71,7 +71,7 @@ public class MatlabSparseFileIteratorTests {
         PrintWriter pw = new PrintWriter(f);
         for (int r = 0; r < testMatrix.length; ++r)
             for (int c = 0; c < testMatrix[0].length; ++c)
-                pw.printf("%d %d %f\n", r+1, c+1, testMatrix[r][c]);
+                pw.println((r+1) + " " + (c+1) + " " + testMatrix[r][c]);
         pw.close();
         return f;
     }

--- a/src/test/java/edu/ucla/sspace/matrix/SvdlibcDenseTextFileIteratorTests.java
+++ b/src/test/java/edu/ucla/sspace/matrix/SvdlibcDenseTextFileIteratorTests.java
@@ -74,11 +74,11 @@ public class SvdlibcDenseTextFileIteratorTests {
         File f = File.createTempFile("unit-test",".dat");
         PrintWriter pw = new PrintWriter(f);
         
-        pw.printf("%d %d\n", testMatrix.length, testMatrix[0].length);
+        pw.println(testMatrix.length + " " + testMatrix[0].length);
 
         for (int r = 0; r < testMatrix.length; ++r) {
             for (int c = 0; c < testMatrix[0].length; ++c)
-                pw.printf("%f ", (float)testMatrix[r][c]);
+                pw.print((float)testMatrix[r][c] + " ");
             pw.println();
         }
 

--- a/src/test/java/edu/ucla/sspace/matrix/SvdlibcSparseTextFileIteratorTests.java
+++ b/src/test/java/edu/ucla/sspace/matrix/SvdlibcSparseTextFileIteratorTests.java
@@ -74,13 +74,13 @@ public class SvdlibcSparseTextFileIteratorTests {
         File f = File.createTempFile("unit-test",".dat");
         PrintWriter pw = new PrintWriter(f);
         
-        pw.printf("%d %d %d\n", testMatrix.length, testMatrix[0].length, 7);
+        pw.println(testMatrix.length + " " + testMatrix[0].length + " " + 7);
 
         for (int c = 0; c < testMatrix[0].length; ++c) {
-            pw.printf("%d\n", numNonZeros[c]);
+            pw.println(numNonZeros[c]);
             for (int r = 0; r < testMatrix.length; ++r)
                 if (testMatrix[r][c] != 0d)
-                    pw.printf("%d %f\n", r, (float)testMatrix[r][c]);
+                    pw.println(r + " " +  (float)testMatrix[r][c]);
         }
 
         pw.close();


### PR DESCRIPTION
Solves #2 

printf, used in some junint test files, uses Locale.getDefault(). This is 'cs' in my case. Because parseDouble uses no locale (I think so) I had the following problem. In some junit tests (see the affected files), matrix double values were stored into tmp files with comma as decimal separator (1,500000 or 2,500000). These values were later read from the tmp files with the help off parseDouble which expected dot as the decimal separator (1.500000 or 2.500000). This lead to NumberFormatException.

The solution which works for me is to use println and print instead of printf (see the code changes). If I understand the problem correclty println and print outputs the numbers using dot as decimal separator (no locale is used as is the case with parseDouble).

Hopefully, there is no need for so many zeros. I output the above mentioned numbers as 1.5 and 2.5.
